### PR TITLE
feat(absences): Support force refresh in LoadAbsences event

### DIFF
--- a/lib/bloc/absence_bloc.dart
+++ b/lib/bloc/absence_bloc.dart
@@ -25,8 +25,8 @@ class AbsenceBloc extends Bloc<AbsenceEvent, AbsenceState> {
     emit(AbsenceLoading());
 
     try {
-      /// Load data only once if not loaded yet
-      if (_allAbsences.isEmpty) {
+      /// Force refresh if the list is empty or if the event requests a refresh
+      if (_allAbsences.isEmpty || event.forceRefresh) {
         _allAbsences = await repository.fetchAbsences();
       }
 

--- a/lib/bloc/absence_event.dart
+++ b/lib/bloc/absence_event.dart
@@ -14,10 +14,15 @@ abstract class AbsenceEvent extends Equatable {
 /// The [page] number is used for pagination.
 
 class LoadAbsences extends AbsenceEvent {
-  const LoadAbsences({required this.page, required this.filters});
+  const LoadAbsences({
+    required this.page,
+    required this.filters,
+    this.forceRefresh = false,
+  });
 
   final int page;
   final AbsenceFilterModel filters;
+  final bool forceRefresh;
 
   @override
   List<Object?> get props => [page, filters];

--- a/test/bloc/absence_bloc_test.dart
+++ b/test/bloc/absence_bloc_test.dart
@@ -137,6 +137,32 @@ void main() {
         isA<AbsenceError>(),
       ],
     );
+
+    blocTest<AbsenceBloc, AbsenceState>(
+      'emits [AbsenceLoading, AbsenceLoaded] and forces fresh fetch when forceRefresh=true',
+      build: () {
+        when(() => repository.fetchAbsences())
+            .thenAnswer((_) async => [mockAbsence]);
+
+        return bloc;
+      },
+      act: (bloc) async {
+        bloc.add(LoadAbsences(page: 0, filters: AbsenceFilterModel()));
+        await Future.delayed(Duration.zero);
+        bloc.add(LoadAbsences(
+          page: 0,
+          filters: AbsenceFilterModel(),
+          forceRefresh: true,
+        ));
+      },
+      expect: () => [
+        AbsenceLoading(),
+        isA<AbsenceLoaded>(),
+        AbsenceLoading(),
+        isA<AbsenceLoaded>(),
+      ],
+      verify: (bloc) => verify(() => repository.fetchAbsences()).called(2),
+    );
   });
 
   group('Absence Bloc Filter', () {


### PR DESCRIPTION
- Added optional 'forceRefresh' flag to LoadAbsences event
- Updated bloc logic to bypass cache when forceRefresh is true
- Ensures latest data is fetched from repository when required
- Updated test case